### PR TITLE
Add extension to normalize.css so sass can find it

### DIFF
--- a/index.scss
+++ b/index.scss
@@ -1,5 +1,5 @@
 @import "primer-support/index.scss";
-@import "normalize.css/normalize";
+@import "normalize.css/normalize.css";
 
 @import "./lib/base.scss";
 @import "./lib/typography-base.scss";


### PR DESCRIPTION
When running sass from the command line like so: `sass --load-path ./node_modules` normalize.css/normalize does not resolve:

```
Error: File to import not found or unreadable: normalize.css/normalize.
       Load path: ./node_modules
        on line 2 of ./node_modules/primer-base/index.scss
        from line 15 of ./node_modules/primer-css/index.scss
```
